### PR TITLE
DM-15111: NCSA DUO and change to ~/notebooks are browser root

### DIFF
--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -15,10 +15,6 @@ This page describes the filesystem directories available in the Notebook Aspect.
      - ✅
      - ✅
      - ✅
-   * - :ref:`filesystem-notebooks`
-     - ✅
-     - ✅
-     - ✅
    * - :ref:`filesystem-datasets`
      -
      - ✅
@@ -38,22 +34,21 @@ $HOME
 =====
 
 Your home directory is just that.
-It’s backed by essentially the same storage as your home directory on `lsst-dev`_ in the LSST Data Facility.
-In fact, your :file:`$HOME` directory in the Notebook Aspect *is* the :file:`$HOME/jhome/` directory on `lsst-dev <https://developer.lsst.io/services/lsst-dev.html>`_. 
+
+The :file:`$HOME` directory is also the base directory for the `JupyterLab file browser`_.
+Notebooks and other files need to be inside the :file:`$HOME` directory (or a subdirectory) for you to open them from the `file browser`_.
+
+Inside the :file:`$HOME` directory is a :file:`~/notebooks` directory that you can use to organize your personal notebooks.
+This directory also contains the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file that you can use to configure the environment your notebooks run in.
 
 Currently there is a 100 GB quota for :file:`$HOME`.
 There is also a limit of 102400 files and subdirectories (inodes) within :file:`$HOME`.
 You can use :ref:`filesystem-project` for larger datasets.
 
-.. _filesystem-notebooks:
+.. note::
 
-~/notebooks
-===========
-
-The :file:`~/notebooks` directory inside your :file:`$HOME` directory is the base directory for the `JupyterLab file browser`_.
-Notebooks and other files need to be inside the :file:`~/notebooks` directory for you to open them from the `file browser`_.
-
-The :file:`~/notebooks` directory is created for you.
+   If you also have an account on `lsst-dev <https://developer.lsst.io/services/lsst-dev.html>`_,
+   you can access your Notebook Aspect home directory via :file:`$HOME/jhome/` from lsst-dev.
 
 .. _filesystem-datasets:
 

--- a/getting-started/logging-in.rst
+++ b/getting-started/logging-in.rst
@@ -6,33 +6,40 @@ You need NCSA Kerberos credentials to log into the LSST Science Platform Noteboo
 Members of LSST receive an NCSA Kerberos account as part of your `onboarding <https://developer.lsst.io/team/onboarding.html>`__.
 If you haven’t onboarded into LSST yet, talk to your T/CAM or sponsor.
 
-Step 1: Use the NCSA VPN with Cisco AnyConnect
-==============================================
+If this is your first time logging in, you'll need to take a moment to set up a VPN:
 
-As a development deployment, the Notebook Aspect is not yet directly accessible from the internet.
-For now, you’ll use NCSA’s VPN, through Cisco AnyConnect, to log into the Notebook Aspect.
+- :ref:`vpn-setup`
 
-.. tip::
+Once you have a working VPN, you can log into the LSST Science Platform Notebook Aspect itself:
 
-   If you are on an approved network, like NOAO, you can skip the VPN and log in directly.
+- :ref:`vpn-login`
+- :ref:`nb-login`
+- :ref:`machine-setup`
 
-To use the NCSA VPN, open `vpn.ncsa.illinois.edu <https://vpn.ncsa.illinois.edu>`__ in your web browser.
-Select ``ncsa-vpn-default`` from the **GROUP** menu and enter your NCSA Kerberos username and password
-(if you've forgotten your password, visit https://identity.ncsa.illinois.edu/reset).
+.. _vpn-setup:
 
-The page installs and starts the Cisco AnyConnect application for you.
+Install and configure the NCSA VPN (Cisco AnyConnect and NCSA DUO)
+==================================================================
 
-.. warning::
+To use the notebook aspect from non-approved networks, you need to use the NCSA VPN.
+This requires you to:
 
-   In most browsers, the Java-based VPN installation will fail.
-   Wait for the direct-download fallback to become available and install the AnyConnect client that way.
+- Install the `Cisco AnyConnect client`_ on your computer.
+- Install and enroll in `NCSA DUO`_ on your iPhone or Android device.
 
-   The certificate expiration of the macOS client download is a known issue.
+Follow the documentation `Connecting to the VPN System`_ (external link) for details on using Cisco AnyConnect VPN client and `NCSA DUO`_ for two-factor authentication.
 
-.. tip::
+.. _vpn-login:
 
-   In the future, you can open the AnyConnect application and enter ``vpn.ncsa.illinois.edu`` to get connected.
-   There's no need to go back to the `vpn.ncsa.illinois.edu <https://vpn.ncsa.illinois.edu>`__ website.
+Step 1: Log into the NCSA VPN
+=============================
+
+If you aren't on an approved network, first activate the NCSA VPN.
+Follow the steps a `Connecting to the VPN System`_ (external link) for details on how to do thiis.
+
+If you've forgotten your password, you can reset it by visiting https://identity.ncsa.illinois.edu/reset.
+
+.. _nb-login:
 
 Step 2: Log in
 ==============
@@ -43,6 +50,8 @@ Click the **Sign in with CILogon** button, then enter your NCSA Kerberos credent
 If you've forgotten your password, you can reset it at https://identity.ncsa.illinois.edu/reset.
 
 Once authentication is complete, you’ll be redirected to the Notebook Aspect’s Spawner page.
+
+.. _machine-setup:
 
 Step 3: Select a machine image and size
 =======================================
@@ -86,3 +95,6 @@ Next steps
 -  :doc:`Explore demo notebooks <notebook-demo>` featuring LSST data analysis.
 
 .. _LSST Science Pipelines: https://pipelines.lsst.io
+.. _NCSA DUO: https://wiki.ncsa.illinois.edu/display/cybersec/Duo+at+NCSA
+.. _Connecting to the VPN System: https://wiki.ncsa.illinois.edu/display/cybersec/Virtual+Private+Network+%28VPN%29+Service#VirtualPrivateNetwork(VPN)Service-ConnectingtotheVPNSystem
+.. _`Cisco AnyConnect client`: https://wiki.ncsa.illinois.edu/display/cybersec/Virtual+Private+Network+%28VPN%29+Service#VirtualPrivateNetwork(VPN)Service-CiscoAnyConnectVPNClientDownloads

--- a/getting-started/notebook-demo.rst
+++ b/getting-started/notebook-demo.rst
@@ -7,7 +7,7 @@ The Notebook Aspect is preloaded with demo notebooks to help you learn about not
 Using the demo notebooks
 ========================
 
-You can find these notebooks in the :file:`notebook-demo` directory of the `JupyterLab file browser <https://jupyterlab.readthedocs.io/en/latest/user/files.html>`_.
+You can find these notebooks in the :file:`notebooks/notebook-demo` directory of the `JupyterLab file browser <https://jupyterlab.readthedocs.io/en/latest/user/files.html>`_.
 Double click the directory, then double click on the notebook to open it.
 You can click **Run** → **Run all Cells** to run the entire notebook, or type :kbd:`shift`\ -\ :kbd:`return` to run one cell at a time.
 
@@ -15,7 +15,7 @@ In the `terminal <https://jupyterlab.readthedocs.io/en/latest/user/terminal.html
 
 .. note::
 
-   The :file:`notebook-demo` directory is hosted at https://github.com/lsst-sqre/notebook-demo.
+   The :file:`notebooks/notebook-demo` directory is hosted at https://github.com/lsst-sqre/notebook-demo.
    Every time you log into the Notebook Aspect, the default branch (called ``prod``) is updated from GitHub.
    Avoid running :command:`git commit` on the ``prod`` branch.
 

--- a/getting-started/repositories.rst
+++ b/getting-started/repositories.rst
@@ -9,12 +9,10 @@ Getting notebooks from GitHub
 =============================
 
 You can clone any Git repository from GitHub to work with its notebooks.
-Be sure to clone into the :file:`~/notebooks/` directory (or a subdirectory of it) so that you can browse the repository with `JupyterLab’s file browser`_:
 
 1. Open the `JupyterLab terminal`_.
-2. ``cd ~/notebooks``
-3. ``git clone https://github.com/{{org}}/{{repo}}``
-4. Open notebooks from `JupyterLab’s file browser`_.
+2. ``git clone https://github.com/{{org}}/{{repo}}``
+3. Open notebooks from `JupyterLab’s file browser`_.
 
 Notebook repositories
 =====================

--- a/science-pipelines/development-tutorial.rst
+++ b/science-pipelines/development-tutorial.rst
@@ -63,7 +63,6 @@ In the same terminal, run:
 
 .. code-block:: bash
 
-   cd ~/notebooks
    git clone https://github.com/lsst/pipe_tasks
    cd pipe_tasks
 
@@ -115,7 +114,7 @@ In a terminal text editor like Vim or Emacs, create or open ``~/notebooks/.user_
 
 .. code-block:: bash
 
-   setup -k -r ~/notebooks/pipe_tasks
+   setup -k -r ~/pipe_tasks
 
 You can check that this works by :ref:`opening a new notebook with the LSST kernel <lsst-kernel-create>` and running:
 
@@ -124,7 +123,7 @@ You can check that this works by :ref:`opening a new notebook with the LSST kern
    import lsst.pipe.tasks
    print(lsst.pipe.tasks.__file__)
 
-As you can see, the module’s path is your clone in :file:`~/notebooks/`, rather than the preinstalled package in :file:`/opt/lsst/software/stack`.
+As you can see, the module’s path is your clone in :file:`~/pipe_tasks/`, rather than the preinstalled package in :file:`/opt/lsst/software/stack`.
 
 .. _eups-tutorial-code:
 
@@ -139,7 +138,7 @@ First, create a Git branch from the terminal:
 
    git checkout -b my-task
 
-Second, create a new file for Task at :file:`python/lsst/pipe/tasks/myTask.py` (inside :file:`~/notebooks/pipe_tasks`) and paste these contents into it:
+Second, create a new file for Task at :file:`python/lsst/pipe/tasks/myTask.py` (inside :file:`~/pipe_tasks`) and paste these contents into it:
 
 .. code-block:: python
 


### PR DESCRIPTION
- Updates the log in docs to take into account NCSA DUO (mostly defers to the NCSA documentation)

- Changes related to `~/notebooks` no longer being privileged as the file browser root.

https://nb.lsst.io/v/DM-15111