### PR TITLE
Expand discussion of standard directories

### DIFF
--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -61,22 +61,26 @@ Within this directory, two items are pre-created:
 - A clone of the `lsst-sqre/notebook-demo`_ repository is created from Github at :file:`~/notebooks/notebook-demo`, and the ``prod`` branch of this repository is regularly updated from Github in this clone.  See the :doc:`discussion of demo notebooks <../getting-started/notebook-demo>` for more details.
 - You can use the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file to configure the environment your notebooks run in.
 
-:file:`~/DATA`
+The ~/DATA directory
+^^^^^^^^^^^^^^^^^^^^
 
 The :file:`~/DATA` directory is pre-created, empty, as a place for tutorial notebooks to load input datasets.
-If it is deleted, some notebooks will attempt to re-create it, while others may fail.
+If you delete it, some notebooks will attempt to re-create it, while others may fail.
 
-:file:`~/WORK`
+The ~/WORK directory
+^^^^^^^^^^^^^^^^^^^^
 
 The :file:`~/WORK` directory is pre-created, empty, as a place for some tutorial notebooks to write outputs (e.g., "rerun" directories).
-If it is deleted, these notebooks may fail.
+If you delete it, these notebooks may fail.
 
-:file:`~/dask`
+The ~/dask directory
+^^^^^^^^^^^^^^^^^^^^
 
 The :file:`~/dask` directory is pre-created and holds an automatically updated `Dask <https://dask.org/>`_ configuration file, :file:`~/dask/dask_worker.yml`.
 This file is recreated on each login, populated with a template that builds dask nodes of the appropriate size and with the appropriate disk mounts.
 
-:file:`~/idleculler`
+The ~/idleculler directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :file:`~/idleculler` directory is used for logfile output from the process that watches for idle sessions.
 This file, :file:`culler.output`, may be deleted when it begins to take up a lot of space; it will be automatically recreated.

--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -36,10 +36,7 @@ $HOME
 Your home directory is just that.
 
 The :file:`$HOME` directory is also the base directory for the `JupyterLab file browser`_.
-Notebooks and other files need to be inside the :file:`$HOME` directory (or a subdirectory) for you to open them from the `file browser`_.
-
-Inside the :file:`$HOME` directory is a :file:`~/notebooks` directory that you can use to organize your personal notebooks.
-This directory also contains the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file that you can use to configure the environment your notebooks run in.
+Notebooks and other files need to be inside the :file:`$HOME` directory (or a subdirectory) for you to see and open them from the `file browser`_.
 
 Currently there is a 100 GB quota for :file:`$HOME`.
 There is also a limit of 102400 files and subdirectories (inodes) within :file:`$HOME`.
@@ -49,6 +46,20 @@ You can use :ref:`filesystem-project` for larger datasets.
 
    If you also have an account on `lsst-dev <https://developer.lsst.io/services/lsst-dev.html>`_,
    you can access your Notebook Aspect home directory via :file:`$HOME/jhome/` from lsst-dev.
+
+Preinstalled subdirectories
+---------------------------
+
+Within the :file:`$HOME` directory a number of directories are pre-created for new users.
+
+:file:`~/notebooks`
+
+The :file:`~/notebooks` directory is intended as the top of a subtree within which you can organize your personal notebooks.
+Within this directory, two items are pre-created:
+
+- A clone of the `lsst-sqre/notebook-demo`_ repository is created from Github at :file:`~/notebooks/notebook-demo`, and the ``prod`` branch of this repository is regularly updated from Github in this clone.  See the :doc:`discussion of demo notebooks <../getting-started/notebook-demo>` for more details.
+- You can use the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file to configure the environment your notebooks run in.
+
 
 .. _filesystem-datasets:
 
@@ -80,3 +91,4 @@ There is no disaster recovery or quota, but there is a purge cycle.
 .. _`Common Dataset Organization and Policy`: https://developer.lsst.io/services/datasets.html
 .. _`JupyterLab file browser`:
 .. _`file browser`: https://jupyterlab.readthedocs.io/en/latest/user/files.html
+.. _`lsst-sqre/notebook-demo`: https://github.com/lsst-sqre/notebook-demo

--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -52,7 +52,8 @@ Preinstalled subdirectories
 
 Within the :file:`$HOME` directory a number of directories are currently pre-created for new users.
 
-:file:`~/notebooks`
+The ~/notebooks directory
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :file:`~/notebooks` directory is intended as the top of a subtree within which you can organize your personal notebooks.
 Within this directory, two items are pre-created:

--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -50,7 +50,7 @@ You can use :ref:`filesystem-project` for larger datasets.
 Preinstalled subdirectories
 ---------------------------
 
-Within the :file:`$HOME` directory a number of directories are pre-created for new users.
+Within the :file:`$HOME` directory a number of directories are currently pre-created for new users.
 
 :file:`~/notebooks`
 
@@ -60,6 +60,25 @@ Within this directory, two items are pre-created:
 - A clone of the `lsst-sqre/notebook-demo`_ repository is created from Github at :file:`~/notebooks/notebook-demo`, and the ``prod`` branch of this repository is regularly updated from Github in this clone.  See the :doc:`discussion of demo notebooks <../getting-started/notebook-demo>` for more details.
 - You can use the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file to configure the environment your notebooks run in.
 
+:file:`~/DATA`
+
+The :file:`~/DATA` directory is pre-created, empty, as a place for tutorial notebooks to load input datasets.
+If it is deleted, some notebooks will attempt to re-create it, while others may fail.
+
+:file:`~/WORK`
+
+The :file:`~/WORK` directory is pre-created, empty, as a place for some tutorial notebooks to write outputs (e.g., "rerun" directories).
+If it is deleted, these notebooks may fail.
+
+:file:`~/dask`
+
+The :file:`~/dask` directory is pre-created and holds an automatically updated `Dask <https://dask.org/>`_ configuration file, :file:`~/dask/dask_worker.yml`.
+This file is recreated on each login, populated with a template that builds dask nodes of the appropriate size and with the appropriate disk mounts.
+
+:file:`~/idleculler`
+
+The :file:`~/idleculler` directory is used for logfile output from the process that watches for idle sessions.
+This file, :file:`culler.output`, may be deleted when it begins to take up a lot of space; it will be automatically recreated.
 
 .. _filesystem-datasets:
 

--- a/environment/directories.rst
+++ b/environment/directories.rst
@@ -58,7 +58,7 @@ The ~/notebooks directory
 The :file:`~/notebooks` directory is intended as the top of a subtree within which you can organize your personal notebooks.
 Within this directory, two items are pre-created:
 
-- A clone of the `lsst-sqre/notebook-demo`_ repository is created from Github at :file:`~/notebooks/notebook-demo`, and the ``prod`` branch of this repository is regularly updated from Github in this clone.  See the :doc:`discussion of demo notebooks <../getting-started/notebook-demo>` for more details.
+- A clone of the `lsst-sqre/notebook-demo`_ repository is created from GitHub at :file:`~/notebooks/notebook-demo`. The ``prod`` branch of this repository is regularly updated from GitHub in this clone.  See the :doc:`../getting-started/notebook-demo` page to learn more.
 - You can use the :ref:`~/notebooks/.user_setups <lsst-kernel-user-setups>` file to configure the environment your notebooks run in.
 
 The ~/DATA directory

--- a/getting-started/repositories.rst
+++ b/getting-started/repositories.rst
@@ -31,7 +31,7 @@ Take a look at these GitHub repositories to find interesting notebooks:
      - Notebooks by LSST Data Management that demonstrate LSST DM software.
    * - `lsst-com/notebooks`_
      - A collection point for LSST Commissioning-related Jupyter notebooks.
-   * - `LSSTScienceCollaborations/DMStackClub`_
+   * - `LSSTScienceCollaborations/StackClub`_
      - Learning the LSST DM Stack, by writing Jupyter notebook tutorials.
    * - `lsst-dm/tutorial-lsst2017`_
      - This is the tutorial notebook from LSST Data Management’s onsite tutorials. Check out the ``answers`` branch to run the notebook all the way through — or try to code it yourself from ``master``.
@@ -39,7 +39,7 @@ Take a look at these GitHub repositories to find interesting notebooks:
 .. _`lsst-sqre/notebook-demo`: https://github.com/lsst-sqre/notebook-demo
 .. _`lsst-dm/dm-demo-notebooks`: https://github.com/lsst-dm/dm-demo-notebooks
 .. _`lsst-com/notebooks`: https://github.com/lsst-com/notebooks
-.. _`LSSTScienceCollaborations/DMStackClub`: https://github.com/LSSTScienceCollaborations/DMStackClub
+.. _`LSSTScienceCollaborations/StackClub`: https://github.com/LSSTScienceCollaborations/StackClub
 .. _`lsst-dm/tutorial-lsst2017`: https://github.com/lsst-dm/tutorial-lsst2017
 
 Suggest a repository

--- a/project/contributing.rst
+++ b/project/contributing.rst
@@ -109,7 +109,7 @@ LSST DM's user documentation is written with soft wrapping, meaning that lines a
 Never hard wrap to an arbitrary line length.
 Soft wrapping makes editing more approachable for more people (particularly those using the GitHub editor) and makes pull request line comments more useful.
 
-More specifically, use `semantic line formatting <http://rhodesmill.org/brandon/2012/one-sentence-per-line/>`__.
+More specifically, use `semantic line formatting <https://rhodesmill.org/brandon/2012/one-sentence-per-line/>`__.
 Generally this means that each sentence should be its own line in the text file.
 
 Titles and headings

--- a/project/implementation.rst
+++ b/project/implementation.rst
@@ -13,8 +13,8 @@ These documents describe the Notebook Aspect and the LSST Science Platform in ge
 
 Related open-source repositories:
 
-- `lsst-sqre/jupyterlabdemo <https://github.com/lsst-sqre/nublado>`__: deployment of JupyterLab for the LSST Notebook Aspect
-- `lsst-sqre/jupyterutils <https://github.com/lsst-sqre/jupyterhubutils>`__: utilities for the JupyterHub environment
+- `lsst-sqre/nublado <https://github.com/lsst-sqre/nublado>`__: deployment of JupyterLab for the LSST Notebook Aspect
+- `lsst-sqre/jupyterhubutils <https://github.com/lsst-sqre/jupyterhubutils>`__: utilities for the JupyterHub environment
 - `lsst-sqre/jupyterlabutils <https://github.com/lsst-sqre/jupyterlabutils>`__: utilities for JupyterLab containers in the LSST Science Platform environment
 - `lsst-sqre/notebook-demo <https://github.com/lsst-sqre/notebook-demo>`__: demo notebooks for the LSST Notebook Aspect
 - `lsst-dm/nb_lsst_io <https://github.com/lsst-dm/nb_lsst_io>`__: this website

--- a/project/implementation.rst
+++ b/project/implementation.rst
@@ -13,8 +13,8 @@ These documents describe the Notebook Aspect and the LSST Science Platform in ge
 
 Related open-source repositories:
 
-- `lsst-sqre/jupyterlabdemo <https://github.com/lsst-sqre/jupyterlabdemo>`__: deployment of JupyterLab for the LSST Notebook Aspect
-- `lsst-sqre/jupyterutils <https://github.com/lsst-sqre/jupyterutils>`__: utilities for the Jupyter environment
+- `lsst-sqre/jupyterlabdemo <https://github.com/lsst-sqre/nublado>`__: deployment of JupyterLab for the LSST Notebook Aspect
+- `lsst-sqre/jupyterutils <https://github.com/lsst-sqre/jupyterhubutils>`__: utilities for the JupyterHub environment
 - `lsst-sqre/jupyterlabutils <https://github.com/lsst-sqre/jupyterlabutils>`__: utilities for JupyterLab containers in the LSST Science Platform environment
 - `lsst-sqre/notebook-demo <https://github.com/lsst-sqre/notebook-demo>`__: demo notebooks for the LSST Notebook Aspect
 - `lsst-dm/nb_lsst_io <https://github.com/lsst-dm/nb_lsst_io>`__: this website


### PR DESCRIPTION
Reacting to a discussion on Slack #dm-lsp-team on 2019-09-12, update the help for the Notebook Aspect with documentation of the current set of pre-created directories in a user's JupyterLab home directory.